### PR TITLE
Fix telegram env

### DIFF
--- a/src/lifeblood/main_scheduler.py
+++ b/src/lifeblood/main_scheduler.py
@@ -139,7 +139,7 @@ def main(argv):
 
     config = SchedulerConfigProviderFileOverrides(
         main_config=get_config('scheduler'),
-        nodes_config=get_config('scheduler.nodes'),
+        nodes_config=get_config('nodes'),
         main_db_location=db_path,
         do_broadcast=opts.broadcast_interval > 0 if opts.broadcast_interval is not None else None,
         broadcast_interval=opts.broadcast_interval,

--- a/src/lifeblood/stock_nodes/telegram_client/nodes/telegram_notifier.py
+++ b/src/lifeblood/stock_nodes/telegram_client/nodes/telegram_notifier.py
@@ -46,6 +46,7 @@ def run_stuff(args, bot_id: str, message: str, fail_on_error: bool = True):
         stderr=subprocess.PIPE,
         env={
             'TELEGRAM_CLIENT_BOTID': bot_id,
+            **({'SYSTEMROOT': os.environ['SYSTEMROOT']} if 'SYSTEMROOT' in os.environ else {}),
         }
     )
     out, err = proc.communicate(message.encode('UTF-8'))


### PR DESCRIPTION
SYSTEMROOT env var is required to be present in proc env for python to initialize properly